### PR TITLE
Extend test and clean-up

### DIFF
--- a/tests/test_qwen3_batched.py
+++ b/tests/test_qwen3_batched.py
@@ -59,6 +59,7 @@ def test_batched_vs_nonbatched_equivalence_with_batched_model(reasoning):
     prompts = [
         "Explain large language models in two sentences.",
         "Explain large language models in one sentence.",
+        "1+1?"
     ]
 
     # Non-batched inputs
@@ -223,6 +224,7 @@ def test_batched_vs_nonbatched_equivalence_with_single_versus_batched_model(reas
     prompts = [
         "Explain large language models in two sentences.",
         "Explain large language models in one sentence.",
+        "1+1?"
     ]
 
     # Non-batched inputs

--- a/tests/test_qwen3_optimized.py
+++ b/tests/test_qwen3_optimized.py
@@ -114,6 +114,7 @@ def test_qwen3_vs_optimized_qwen3(reasoning):
     prompts = [
         "Explain large language models in two sentences.",
         "Explain large language models in one sentence.",
+        "1+1?"
     ]
 
     single_inputs = [


### PR DESCRIPTION
Adds a shorter prompt to the batched kv cache tests to ensure it still works equivalently with more padding.

Fixes #33