### PR TITLE
Lower PyTorch dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "jupyterlab>=4.4.7",
-    "torch>=2.9.0",
+    "torch>=2.8.0",
     "tokenizers>=0.21.2",
     "nbformat>=5.10.4",
     "sympy>=1.14.0", # For verifier in ch03

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 reasoning-from-scratch >= 0.1.2
-torch >= 2.7.1
+sympy>=1.14.0  # For verifier in ch03
+torch >= 2.8.0
 tokenizers >= 0.21.2


### PR DESCRIPTION
As readers reported, PyTorch 2.9 installs the CPU-only version by default on some systems (https://livebook.manning.com/forum?comment=581134). Since 2.9 is not strictly required, pinning 2.8 as the minimum dependency might make things easier.