### PR TITLE
Torch.compile on Windows with autotune

### DIFF
--- a/ch02/01_main-chapter-code/ch02_main.ipynb
+++ b/ch02/01_main-chapter-code/ch02_main.ipynb
@@ -1338,7 +1338,7 @@
    "source": [
     "---\n",
     "\n",
-    "**Windows note**\n",
+    "**Windows note 1**\n",
     "\n",
     "- Compilation can be tricky on Windows\n",
     "- `torch.compile()` uses Inductor, which JIT-compiles kernels and needs a working C/C++ toolchain\n",
@@ -1349,6 +1349,10 @@
     "  - Here, it is important to install the English language package when installing Visual Studio 2022 to avoid a UTF-8 error\n",
     "  - Also, please note that the code needs to be run via the \"Visual Studio 2022 Developer Command Prompt\" rather than a notebook\n",
     "- If this setup proves tricky, you can skip compilation; **compilation is optional, and all code examples work fine without it**\n",
+    "\n",
+    "**Windows note 2**\n",
+    "\n",
+    "- Readers reported that there is no speed-up when running `torch.compile` with default settings on Windows; however, running `torch.compile` with the `\"max-autotune\"` mode resulted in a 2x speed-up: `torch.compile(model, mode=\"max-autotune\")`\n",
     "\n",
     "---"
    ]


### PR DESCRIPTION
Readers reported that there is no speed-up when running `torch.compile` with default settings on Windows; however, running `torch.compile` with the `"max-autotune"` mode resulted in a 2x speed-up: `torch.compile(model, mode="max-autotune")`