### PR TITLE
Robustify against recursion error

### DIFF
--- a/ch03/01_main-chapter-code/ch03_main.ipynb
+++ b/ch03/01_main-chapter-code/ch03_main.ipynb
@@ -1056,7 +1056,7 @@
     "            evaluate=True,\n",
     "        )\n",
     "    except (SympifyError, SyntaxError, TypeError,\n",
-    "            IndexError, TokenError, ValueError):\n",
+    "            IndexError, TokenError, ValueError, RecursionError):\n",
     "        return None"
    ]
   },

--- a/reasoning_from_scratch/ch03.py
+++ b/reasoning_from_scratch/ch03.py
@@ -308,7 +308,7 @@ def sympy_parser(expr):
             evaluate=True,
         )
     except (SympifyError, SyntaxError, TypeError,
-            IndexError, TokenError, ValueError):
+            IndexError, TokenError, ValueError, RecursionError):
         return None
 
 


### PR DESCRIPTION
Bad RL checkpoints can crash the evaluation script with recursion error. E.g., a bad model may raise errors like  

```python
...
Symbol ('l' )*Symbol ('e' )*Symbol ('d' )*Symbol ('i' )*Symbol ('m' )*Symbol ('e' )*Symbol ('n' )*Symbol ('s' )*Symbol ('i' )*Symbol ('o' )*Symbol ('n' )*Symbol ('s' )*Symbol ('s' )*Symbol ('q' )*Symbol ('u' )*Symbol ('a' )*Symbol ('r' )*Symbol ('e' )*Symbol ('t' )*Symbol ('r' )*Symbol ('i' )*Symbol ('a' )*Symbol ('n' )*Symbol ('g' )*Symbol ('l' )*Symbol ('e' )"

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/rasbt/jupyterlab/reasoning/reasoning-from-scratch/./ch03/02_math500-verifier-scripts/evaluate_math500.py", line 114, in <module>
    num_correct, num_examples, acc = evaluate_math500_stream(
                                     ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rasbt/jupyterlab/reasoning/reasoning-from-scratch/reasoning_from_scratch/ch03.py", line 528, in evaluate_math500_stream
    is_correct = grade_answer(            # 4. Grade answer
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rasbt/jupyterlab/reasoning/reasoning-from-scratch/reasoning_from_scratch/ch03.py", line 371, in grade_answer
    result = all(
             ^^^^
  File "/home/rasbt/jupyterlab/reasoning/reasoning-from-scratch/reasoning_from_scratch/ch03.py", line 372, in <genexpr>
    equality_check(gt, pred)
  File "/home/rasbt/jupyterlab/reasoning/reasoning-from-scratch/reasoning_from_scratch/ch03.py", line 321, in equality_check
    gtruth, pred = sympy_parser(expr_gtruth), sympy_parser(expr_pred)
                                              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rasbt/jupyterlab/reasoning/reasoning-from-scratch/reasoning_from_scratch/ch03.py", line 297, in sympy_parser
    return spp.parse_expr(
           ^^^^^^^^^^^^^^^
  File "/home/rasbt/jupyterlab/reasoning/reasoning-from-scratch/.venv/lib/python3.12/site-packages/sympy/parsing/sympy_parser.py", line 1090, in parse_expr
    raise e from ValueError(f"Error from parse_expr with transformed code: {code!r}")
  File "/home/rasbt/jupyterlab/reasoning/reasoning-from-scratch/.venv/lib/python3.12/site-packages/sympy/parsing/sympy_parser.py", line 1081, in parse_expr
    rv = eval_expr(code, local_dict, global_dict)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rasbt/jupyterlab/reasoning/reasoning-from-scratch/.venv/lib/python3.12/site-packages/sympy/parsing/sympy_parser.py", line 905, in eval_expr
    expr = eval(
           ^^^^^
RecursionError: maximum recursion depth exceeded during compilation
```