### PR TITLE
Model evaluation script for json files

### DIFF
--- a/ch03/02_math500-verifier-scripts/README.md
+++ b/ch03/02_math500-verifier-scripts/README.md
@@ -8,6 +8,7 @@
 
 - [evaluate_math500.py](evaluate_math500.py): standalone script to evaluate models on the MATH-500 dataset
 - [evaluate_math500_batched.py](evaluate_math500_batched.py): same as above, but processes multiple examples in parallel during generation (for higher throughput)
+- [evaluate_json.py](evaluate_json.py): evaluate saved records JSON/JSONL files and report accuracy
 
 Both evaluation scripts import functionality from the [`reasoning_from_scratch`](../../reasoning_from_scratch) package to avoid code duplication. (See [chapter 2 setup instructions](../../ch02/02_setup-tips/python-instructions.md) for installation details.)
 
@@ -78,6 +79,7 @@ Extra options:
                         memory-intensive, but easier to debug.
 ```
 
+
 &nbsp;
 
 
@@ -124,3 +126,23 @@ Some PyTorch ops used in efficient batched inference are not yet supported on MP
 
 
 - The accuracy of the base model  is 15.6% (78/500); the accuracy of the reasoning model is 50.8% (254/500).
+
+
+&nbsp;
+## `evaluate_json.py` usage
+
+Use this if you already have saved records and only want to (re)compute accuracy:
+
+```bash
+uv run evaluate_json.py --json_path math500_base-mps-evaluate-script.jsonl
+# Accuracy 15.6% (78/500)
+
+Optional keys:
+
+```bash
+uv run evaluate_json.py \
+  --json_path my_records.json \
+  --gtruth_answer "gtruth_answer" \
+  --generated_text "generated_text"
+```
+

--- a/ch03/02_math500-verifier-scripts/evaluate_json.py
+++ b/ch03/02_math500-verifier-scripts/evaluate_json.py
@@ -1,0 +1,104 @@
+# Copyright (c) Sebastian Raschka under Apache License 2.0 (see LICENSE.txt)
+# Source for "Build a Reasoning Model (From Scratch)": https://mng.bz/lZ5B
+# Code repository: https://github.com/rasbt/reasoning-from-scratch
+
+import argparse
+import json
+from pathlib import Path
+
+from reasoning_from_scratch.ch03 import (
+    extract_final_candidate,
+    grade_answer,
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--json_path",
+        type=str,
+        required=True,
+        help="Path to the records file (.json or .jsonl).",
+    )
+    parser.add_argument(
+        "--gtruth_answer",
+        type=str,
+        default="gtruth_answer",
+        help="Key name for the ground-truth answer. Default: gtruth_answer",
+    )
+    parser.add_argument(
+        "--generated_text",
+        type=str,
+        default="generated_text",
+        help="Key name for generated model output. Default: generated_text",
+    )
+    return parser.parse_args()
+
+
+def load_records(json_path):
+    path = Path(json_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Input file not found: {path}")
+
+    with path.open("r", encoding="utf-8") as f:
+        try:
+            parsed = json.load(f)
+        except json.JSONDecodeError:
+            f.seek(0)
+            records = []
+            for line_num, line in enumerate(f, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Invalid JSON on line {line_num} in {path}: {exc}"
+                    ) from exc
+            return records
+
+    if isinstance(parsed, list):
+        return parsed
+    if isinstance(parsed, dict):
+        if "records" in parsed and isinstance(parsed["records"], list):
+            return parsed["records"]
+        return [parsed]
+
+    raise ValueError(
+        f"Unsupported JSON root type in {path}: {type(parsed).__name__}"
+    )
+
+
+def evaluate_records(records, gtruth_key, generated_text_key):
+    num_examples = len(records)
+    num_correct = 0
+
+    for idx, record in enumerate(records, start=1):
+        if not isinstance(record, dict):
+            raise ValueError(
+                f"Record {idx} is not a JSON object: {type(record).__name__}"
+            )
+
+        if gtruth_key not in record:
+            raise KeyError(f"Record {idx} is missing key: {gtruth_key}")
+        if generated_text_key not in record:
+            raise KeyError(f"Record {idx} is missing key: {generated_text_key}")
+
+        extracted = extract_final_candidate(record[generated_text_key])
+        is_correct = grade_answer(extracted, record[gtruth_key])
+        num_correct += int(is_correct)
+
+    acc = num_correct / num_examples if num_examples else 0.0
+    return num_correct, num_examples, acc
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    records = load_records(args.json_path)
+    num_correct, num_examples, acc = evaluate_records(
+        records=records,
+        gtruth_key=args.gtruth_answer,
+        generated_text_key=args.generated_text,
+    )
+    print(f"Accuracy: {acc*100:.1f}% ({num_correct}/{num_examples})")

--- a/tests/test_math500_scripts.py
+++ b/tests/test_math500_scripts.py
@@ -2,6 +2,7 @@
 # Source for "Build a Reasoning Model (From Scratch)": https://mng.bz/lZ5B
 # Code repository: https://github.com/rasbt/reasoning-from-scratch
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -12,6 +13,7 @@ import pytest
 SCRIPT_PATHS = [
     Path("ch03/02_math500-verifier-scripts/evaluate_math500_batched.py"),
     Path("ch03/02_math500-verifier-scripts/evaluate_math500.py"),
+    Path("ch03/02_math500-verifier-scripts/evaluate_json.py"),
     Path("ch04/02_math500-inference-scaling-scripts/self_consistency_math500.py"),
     Path("ch04/02_math500-inference-scaling-scripts/cot_prompting_math500.py"),
 ]
@@ -35,3 +37,69 @@ def test_script_help_runs_without_import_errors(script_path):
 
     assert result.returncode == 0, result.stderr
     assert "usage" in result.stdout.lower()
+
+
+def test_evaluate_json_script_jsonl(tmp_path):
+
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "ch03/02_math500-verifier-scripts/evaluate_json.py"
+    assert script_path.exists(), f"Expected script at {script_path}"
+
+    records_path = tmp_path / "records.jsonl"
+    records = [
+        {
+            "gtruth_answer": "2/3",
+            "generated_text": "Let's solve this.\n\\boxed{2/3}",
+        },
+        {
+            "gtruth_answer": "5",
+            "generated_text": "Final answer is \\boxed{4}",
+        },
+    ]
+    records_path.write_text(
+        "\n".join(json.dumps(item) for item in records) + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), "--json_path", str(records_path)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Accuracy: 50.0% (1/2)" in result.stdout
+
+
+def test_evaluate_json_script_custom_keys(tmp_path):
+
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = repo_root / "ch03/02_math500-verifier-scripts/evaluate_json.py"
+    assert script_path.exists(), f"Expected script at {script_path}"
+
+    records_path = tmp_path / "records.json"
+    records = [
+        {"answer_key": "7", "model_output": "Answer: \\boxed{7}"},
+        {"answer_key": "1/4", "model_output": "Answer: \\boxed{3/4}"},
+    ]
+    records_path.write_text(json.dumps(records), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script_path),
+            "--json_path",
+            str(records_path),
+            "--gtruth_answer",
+            "answer_key",
+            "--generated_text",
+            "model_output",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Accuracy: 50.0% (1/2)" in result.stdout


### PR DESCRIPTION
This adds an additional convenience script to (re)compute the model accuracy from .json/.jsonl files:

```bash
uv run evaluate_json.py --json_path math500_base-mps-evaluate-script.jsonl
# Accuracy 15.6% (78/500)
```