### PR TITLE
Make calc_next_token_logprobas consistent with chapter 5

### DIFF
--- a/reasoning_from_scratch/__init__.py
+++ b/reasoning_from_scratch/__init__.py
@@ -5,7 +5,7 @@
 """
 Reasoning package used by the "Reasoning Models From Scratch" book.
 
-Copyright (c) 2025, Sebastian Raschka
+Copyright (c) 2025-2026, Sebastian Raschka
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,4 +22,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"

--- a/reasoning_from_scratch/ch05.py
+++ b/reasoning_from_scratch/ch05.py
@@ -74,7 +74,7 @@ def calc_next_token_probas(model, tokenizer, prompt, device):
 
 
 @torch.inference_mode()
-def calc_next_token_logprobas(model, tokenizer, prompt, device):
+def calc_next_token_logprobas(model, tokenizer, prompt, device, show=True):
 
     token_ids = torch.tensor(tokenizer.encode(prompt), device=device)
 
@@ -86,15 +86,14 @@ def calc_next_token_logprobas(model, tokenizer, prompt, device):
     next_ids = token_ids[1:]
     next_token_logprobas = all_logprobas[t_idx, next_ids]
 
-    print(
-        "Next-token log-probabilities:",
-        [p.item() for p in next_token_logprobas]
-    )
     # We replace the product with a sum
-    print(
-        "Joint log-probability:",
-        torch.sum(next_token_logprobas)
-    )
+    sum_next_token_logprobas = torch.sum(next_token_logprobas)
+
+    if show:
+        print("Next-token log-probabilities:", next_token_logprobas)
+        print("Joint log-probability:", sum_next_token_logprobas)
+    else:
+        return next_token_logprobas, sum_next_token_logprobas
 
 
 @torch.inference_mode()


### PR DESCRIPTION
The `calc_next_token_logprobas` in the `reasoning_from_scratch` package was missing the `show` argument.