### PR TITLE
[6.8] update text to match cell output

### DIFF
--- a/ch06/01_main-chapter-code/ch06_main.ipynb
+++ b/ch06/01_main-chapter-code/ch06_main.ipynb
@@ -1145,7 +1145,7 @@
    "metadata": {},
    "source": [
     "- Note that we don't use `.item()` in `torch.sum(next_token_logps)` so that PyTorch returns a tensor (rather than a Python float), which is important for the gradient calculation\n",
-    "- As we can see, the resulting value (-6.5853) is almost identical to that we got previously when rescaling the `avg_logprob_val` by the number of answer tokens (-6.5625); the minor differences can be attributed to floating point rounding behavior "
+    "- As we can see, the resulting value (-16.2998) is almost identical to that we got previously when rescaling the `avg_logprob_val` by the number of answer tokens (-16.2390); the minor differences can be attributed to floating point rounding behavior "
    ]
   },
   {

--- a/ch06/01_main-chapter-code/ch06_main.ipynb
+++ b/ch06/01_main-chapter-code/ch06_main.ipynb
@@ -1566,7 +1566,7 @@
     "    if steps is None:\n",
     "        steps = len(math_data)\n",
     "\n",
-    "    # Stage 1: initialize optimize\n",
+    "    # Stage 1: initialize optimizer\n",
     "    # (the model was already initialized outside the function)\n",
     "    optimizer = torch.optim.AdamW(model.parameters(), lr=lr)\n",
     "    model.train()\n",


### PR DESCRIPTION
Hi Sebastian,

I updated a bullet point that still reflected an older run (−6) so it matches the current cell outputs (~−16), which could confuse readers.

Book-wise, the equivalent part in p.269 is fine, it mentions -16.24 and the previous output was -16.23, so readers will get it.

edit: fix a little typo too