### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/ch08/02_generate_distillation_data/other_providers/minimax/README.md
+++ b/ch08/02_generate_distillation_data/other_providers/minimax/README.md
@@ -9,7 +9,7 @@ The input and output JSON formats are the same as the ones documented in the [ma
 &nbsp;
 ## Files
 
-- [generate_with_minimax.py](generate_with_minimax.py): Uses MiniMax's cloud API to generate the model answers for distillation. MiniMax offers models like MiniMax-M2.7 (1M context window) through an OpenAI-compatible API.
+- [generate_with_minimax.py](generate_with_minimax.py): Uses MiniMax's cloud API to generate the model answers for distillation. MiniMax offers models like MiniMax-M3 (512K context window) through an OpenAI-compatible API.
 
 &nbsp;
 ## MiniMax setup
@@ -19,10 +19,9 @@ The input and output JSON formats are the same as the ones documented in the [ma
 3. Save the API key in a secure location (e.g., a password manager)
 
 Available models:
-- `MiniMax-M2.7` — Latest model with 1M context window (default)
-- `MiniMax-M2.7-highspeed` — Faster variant optimized for throughput
-- `MiniMax-M2.5` — Previous generation with 204K context
-- `MiniMax-M2.5-highspeed` — Faster variant of M2.5
+- `MiniMax-M3` — Latest model with 512K context window, 128K max output (default)
+- `MiniMax-M2.7` — Previous generation with 1M context window
+- `MiniMax-M2.7-highspeed` — Faster variant of M2.7 optimized for throughput
 
 &nbsp;
 ## Data generation with MiniMax
@@ -33,7 +32,7 @@ The MiniMax script works similarly to the OpenRouter script:
 MINIMAX_API_KEY="YOUR_API_KEY" uv run other_providers/minimax/generate_with_minimax.py \
   --math_json math_train_sample.json \
   --dataset_size 5 \
-  --model MiniMax-M2.7 \
+  --model MiniMax-M3 \
   --num_processes 1 \
   --out_file sample_minimax_outputs.json
 ```
@@ -52,7 +51,7 @@ To generate teacher answers for the 500-example MATH-500 set, you can omit `--ma
 ```bash
 MINIMAX_API_KEY="YOUR_API_KEY" uv run other_providers/minimax/generate_with_minimax.py \
   --dataset_size 500 \
-  --model MiniMax-M2.7 \
+  --model MiniMax-M3 \
   --num_processes 1 \
   --out_file math500_minimax_distill.json
 ```
@@ -71,7 +70,7 @@ https://raw.githubusercontent.com/rasbt/math_full_minus_math500/refs/heads/main/
 MINIMAX_API_KEY="YOUR_API_KEY" uv run other_providers/minimax/generate_with_minimax.py \
   --math_json math_full_minus_math500.json \
   --dataset_size 12000 \
-  --model MiniMax-M2.7 \
+  --model MiniMax-M3 \
   --num_processes 50 \
   --resume \
   --out_file math12000_minimax_distill.json

--- a/ch08/02_generate_distillation_data/other_providers/minimax/generate_with_minimax.py
+++ b/ch08/02_generate_distillation_data/other_providers/minimax/generate_with_minimax.py
@@ -65,11 +65,10 @@ def parse_args():
     parser.add_argument(
         "--model",
         type=str,
-        default="MiniMax-M2.7",
+        default="MiniMax-M3",
         help=(
             "MiniMax model name. Available models: "
-            "MiniMax-M2.7, MiniMax-M2.7-highspeed, "
-            "MiniMax-M2.5, MiniMax-M2.5-highspeed"
+            "MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed"
         ),
     )
     parser.add_argument(

--- a/ch08/02_generate_distillation_data/other_providers/minimax/test_minimax_distillation.py
+++ b/ch08/02_generate_distillation_data/other_providers/minimax/test_minimax_distillation.py
@@ -176,6 +176,9 @@ class TestRenderPrompt:
 
 class TestModelToFilename:
     def test_standard_model(self, minimax_mod):
+        assert minimax_mod.model_to_filename("MiniMax-M3") == "math500_minimax_m3_full_answers.json"
+
+    def test_legacy_model(self, minimax_mod):
         assert minimax_mod.model_to_filename("MiniMax-M2.7") == "math500_minimax_m2_7_full_answers.json"
 
     def test_highspeed_model(self, minimax_mod):
@@ -317,7 +320,7 @@ class TestQueryMiniMaxChat:
         with patch.object(minimax_mod.request, "urlopen", return_value=mock_response):
             result = minimax_mod.query_minimax_chat(
                 prompt="Reply with OK.",
-                model="MiniMax-M2.7",
+                model="MiniMax-M3",
                 api_key="test-key",
                 max_new_tokens=8,
                 temperature=0.7,
@@ -341,7 +344,7 @@ class TestQueryMiniMaxChat:
             with pytest.raises(RuntimeError, match="Failed to query MiniMax"):
                 minimax_mod.query_minimax_chat(
                     prompt="test",
-                    model="MiniMax-M2.7",
+                    model="MiniMax-M3",
                     api_key="test-key",
                     max_new_tokens=8,
                     temperature=0.7,
@@ -371,7 +374,7 @@ class TestQueryMiniMaxChat:
         with patch.object(minimax_mod.request, "urlopen", side_effect=capture_urlopen):
             minimax_mod.query_minimax_chat(
                 prompt="test",
-                model="MiniMax-M2.7",
+                model="MiniMax-M3",
                 api_key="test-key",
                 max_new_tokens=8,
                 temperature=0.0,
@@ -410,7 +413,7 @@ class TestGenerateRow:
             result = minimax_mod.generate_row(
                 row=row,
                 shorter_answers_prompt=False,
-                model="MiniMax-M2.7",
+                model="MiniMax-M3",
                 api_key="test-key",
                 max_new_tokens=2048,
                 temperature=0.7,
@@ -441,7 +444,7 @@ class TestRealMiniMaxAPI:
         api_key = os.environ["MINIMAX_API_KEY"]
         result = minimax_mod.query_minimax_chat(
             prompt="What is 2+2? Reply with just the number.",
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             api_key=api_key,
             max_new_tokens=64,
             temperature=0.7,


### PR DESCRIPTION
## Summary

Upgrade the MiniMax distillation provider in `ch08/02_generate_distillation_data/other_providers/minimax/` to use the latest MiniMax-M3 model as the default.

## Changes

- Add `MiniMax-M3` to the model selection list and set it as the new default
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove the older `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` entries from the docs
- Update related unit tests to cover the M3 model id and filename

## Why

MiniMax-M3 is the new flagship model with a 512K context window, 128K max output, and image input support. Using it as the default keeps the distillation script aligned with the latest available teacher model while still allowing users to opt back into M2.7 / M2.7-highspeed.

## Testing

- `pytest ch08/02_generate_distillation_data/other_providers/minimax/test_minimax_distillation.py` passes locally (35 passed, 3 real-API tests skipped without `MINIMAX_API_KEY`)
- `--help` runs cleanly with the updated default