### PR TITLE
Align split_data validation_size default with CLI default

### DIFF
--- a/ch08/04_train_with_distillation/distill.py
+++ b/ch08/04_train_with_distillation/distill.py
@@ -283,7 +283,7 @@ def load_json(path):
     return data
 
 
-def split_data(data, validation_size=50, seed=123):
+def split_data(data, validation_size=25, seed=123):
     data = list(data)
     rnd = random.Random(seed)
     rnd.shuffle(data)

--- a/ch08/04_train_with_distillation/distill_batched.py
+++ b/ch08/04_train_with_distillation/distill_batched.py
@@ -112,7 +112,7 @@ def load_json(path):
     return data
 
 
-def split_data(data, validation_size=50, seed=123):
+def split_data(data, validation_size=25, seed=123):
     data = list(data)
     rnd = random.Random(seed)
     rnd.shuffle(data)


### PR DESCRIPTION
## Summary

In `ch08/04_train_with_distillation/distill.py` and `distill_batched.py`, the `--validation_size` CLI argument defaults to `25`, but the `split_data()` function signature defaults to `50`. Since `main()` always passes the CLI value, the `50` only takes effect for direct callers of `split_data()` — but the inconsistency is confusing when reading the code.

This aligns both function signatures to `25`, matching the CLI default and the `hf_trainer.py` scripts in `ch08/06_use_via_huggingface`, which already use `validation_size=25`.

## Changes
- `distill.py`: `split_data(data, validation_size=50, ...)` → `validation_size=25`
- `distill_batched.py`: same change

No behavior change for anyone running the scripts via the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)